### PR TITLE
Hide feed posts from accounts you don't follow (Instagram + LinkedIn)

### DIFF
--- a/content-common.js
+++ b/content-common.js
@@ -34,10 +34,12 @@ const CONFIG = {
     ytShortsShelves: true,
     ytMostRelevantShelf: true,
     igReelsNav: true,
+    igSuggested: true,
     fbReelsNav: true,
     fbPeopleYouMightKnow: true,
     liFeed: true,
     liAddFeed: true,
+    liSuggested: true,
   },
 };
 const FocusState = {
@@ -165,7 +167,7 @@ const Utils = {
     });
     document
       .querySelectorAll(
-        ".focus-tube-warning, .ft-stories-overlay, .ft-linkedin-overlay",
+        ".focus-tube-warning, .ft-stories-overlay, .ft-linkedin-overlay, .ft-ig-stub, .ft-li-stub",
       )
       .forEach((el) => el.remove());
   },
@@ -445,12 +447,20 @@ const Utils = {
       active && allowIg && CONFIG.visualHiding.igReelsNav,
     );
     document.body.classList.toggle(
+      "ft-hide-ig-suggested",
+      active && allowIg && CONFIG.visualHiding.igSuggested,
+    );
+    document.body.classList.toggle(
       "ft-hide-li-feed",
       active && allowLi && CONFIG.visualHiding.liFeed,
     );
     document.body.classList.toggle(
       "ft-hide-li-addfeed",
       active && allowLi && CONFIG.visualHiding.liAddFeed,
+    );
+    document.body.classList.toggle(
+      "ft-hide-li-suggested",
+      active && allowLi && CONFIG.visualHiding.liSuggested,
     );
   },
   lockVideo: function () {
@@ -925,10 +935,12 @@ const UI = {
       "hide_yt_shorts_shelves",
       "hide_yt_most_relevant_shelf",
       "hide_ig_reels_nav",
+      "hide_ig_suggested",
       "hide_fb_reels_nav",
       "hide_fb_people_you_might_know",
       "hide_li_feed",
       "hide_li_addfeed",
+      "hide_li_suggested",
       "ft_debug",
     ],
     (res) => {
@@ -969,10 +981,12 @@ const UI = {
         ytShortsShelves: res.hide_yt_shorts_shelves !== false,
         ytMostRelevantShelf: res.hide_yt_most_relevant_shelf !== false,
         igReelsNav: res.hide_ig_reels_nav !== false,
+        igSuggested: res.hide_ig_suggested !== false,
         fbReelsNav: res.hide_fb_reels_nav !== false,
         fbPeopleYouMightKnow: res.hide_fb_people_you_might_know !== false,
         liFeed: res.hide_li_feed !== false,
         liAddFeed: res.hide_li_addfeed !== false,
+        liSuggested: res.hide_li_suggested !== false,
       };
       Utils._debugEnabled = res.ft_debug === true;
       Utils.ensureBody(() => {
@@ -1144,6 +1158,11 @@ const UI = {
         changes.hide_ig_reels_nav.newValue !== false;
       Utils.applyVisualHidingClasses();
     }
+    if (changes.hide_ig_suggested) {
+      CONFIG.visualHiding.igSuggested =
+        changes.hide_ig_suggested.newValue !== false;
+      Utils.applyVisualHidingClasses();
+    }
     if (changes.hide_fb_reels_nav) {
       CONFIG.visualHiding.fbReelsNav =
         changes.hide_fb_reels_nav.newValue !== false;
@@ -1156,6 +1175,11 @@ const UI = {
     }
     if (changes.hide_li_feed) {
       CONFIG.visualHiding.liFeed = changes.hide_li_feed.newValue !== false;
+      Utils.applyVisualHidingClasses();
+    }
+    if (changes.hide_li_suggested) {
+      CONFIG.visualHiding.liSuggested =
+        changes.hide_li_suggested.newValue !== false;
       Utils.applyVisualHidingClasses();
     }
     if (changes.hide_li_addfeed) {

--- a/content-common.js
+++ b/content-common.js
@@ -103,6 +103,44 @@ const Utils = {
       return false;
     }
   },
+  // The extension's mark, drawn inline. Nothing here loads an image from
+  // chrome-extension://, because chrome.runtime.getURL() returns
+  // "chrome-extension://invalid/" once the extension context has been replaced
+  // - which happens on every reload of an unpacked build while pages are open
+  // - and the page then retries that URL for as long as it stays open.
+  createBadge: function (className) {
+    const NS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(NS, "svg");
+    svg.setAttribute("viewBox", "0 0 64 64");
+    svg.setAttribute("aria-hidden", "true");
+    if (className) svg.setAttribute("class", className);
+    const plate = document.createElementNS(NS, "rect");
+    plate.setAttribute("x", "2");
+    plate.setAttribute("y", "2");
+    plate.setAttribute("width", "60");
+    plate.setAttribute("height", "60");
+    plate.setAttribute("rx", "16");
+    plate.setAttribute("fill", "#4facfe");
+    const ring = document.createElementNS(NS, "circle");
+    ring.setAttribute("cx", "32");
+    ring.setAttribute("cy", "32");
+    ring.setAttribute("r", "15");
+    ring.setAttribute("fill", "none");
+    ring.setAttribute("stroke", "#fff");
+    ring.setAttribute("stroke-width", "4");
+    const slash = document.createElementNS(NS, "line");
+    slash.setAttribute("x1", "21");
+    slash.setAttribute("y1", "21");
+    slash.setAttribute("x2", "43");
+    slash.setAttribute("y2", "43");
+    slash.setAttribute("stroke", "#fff");
+    slash.setAttribute("stroke-width", "4");
+    slash.setAttribute("stroke-linecap", "round");
+    svg.appendChild(plate);
+    svg.appendChild(ring);
+    svg.appendChild(slash);
+    return svg;
+  },
   getExtensionUrl: function (path) {
     try {
       if (!chrome.runtime?.id || !chrome.runtime?.getURL) return "";
@@ -703,10 +741,7 @@ const UI = {
     const target = document.body || document.documentElement;
     const card = document.createElement("div");
     card.className = "focus-tube-card";
-    const img = document.createElement("img");
-    const iconUrl = Utils.getExtensionUrl("icons/icon128.png");
-    if (iconUrl) img.src = iconUrl;
-    img.className = "focus-tube-icon-img";
+    const img = Utils.createBadge("focus-tube-icon-img");
     let headerText =
       type === "strict" ? "Strict Mode Active" : "Distraction Blocked";
     let bodyText = "FocusTube is keeping you productive.";
@@ -848,14 +883,9 @@ const UI = {
     const toast = document.createElement("div");
     toast.id = "ft-toast";
     toast.style.cssText = `position: fixed; top: 24px; right: 24px; background: #1f1f1f; color: #fff; padding: 16px 24px; border-radius: 12px; box-shadow: 0 10px 40px rgba(0,0,0,0.4); z-index: 2147483647; font-family: sans-serif; border: 1px solid rgba(255,255,255,0.1); display: flex; align-items: center; gap: 15px; opacity: 0; transform: translateY(-20px); transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1); min-width: 300px;`;
-    const iconUrl = Utils.getExtensionUrl("icons/icon128.png");
-    if (iconUrl) {
-      const icon = document.createElement("img");
-      icon.src = iconUrl;
-      icon.alt = "";
-      icon.style.cssText = "width:32px;height:32px;border-radius:8px;";
-      toast.appendChild(icon);
-    }
+    const icon = Utils.createBadge();
+    icon.style.cssText = "width:32px;height:32px;flex:0 0 auto;";
+    toast.appendChild(icon);
     const textWrap = document.createElement("div");
     const titleEl = document.createElement("div");
     titleEl.textContent = title;
@@ -890,14 +920,9 @@ const UI = {
             box-shadow: 0 10px 40px rgba(0,0,0,0.25), 0 0 0 1px rgba(255,255,255,0.1); 
             opacity: 0; transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
         `;
-    const iconUrl = Utils.getExtensionUrl("icons/icon128.png");
-    if (iconUrl) {
-      const icon = document.createElement("img");
-      icon.src = iconUrl;
-      icon.alt = "";
-      icon.style.cssText = "width:24px;height:24px;border-radius:6px;";
-      n.appendChild(icon);
-    }
+    const icon = Utils.createBadge();
+    icon.style.cssText = "width:24px;height:24px;flex:0 0 auto;";
+    n.appendChild(icon);
     const message = document.createElement("span");
     message.textContent = "Strict Mode prevented access.";
     n.appendChild(message);

--- a/content-fb.js
+++ b/content-fb.js
@@ -338,8 +338,6 @@ const Facebook = {
     );
   },
   showStoriesOverlay: function () {
-    const iconUrl = Utils.getExtensionUrl("icons/icon48.png");
-    if (!iconUrl) return;
     if (document.getElementById(this.storiesOverlayId)) return;
     const storiesContainer = document.querySelector('[aria-label="Stories"]');
     if (!storiesContainer) return;
@@ -353,9 +351,7 @@ const Facebook = {
     overlay.id = this.storiesOverlayId;
     overlay.className = "ft-stories-overlay";
     if (CONFIG.isDarkMode) overlay.classList.add("dark");
-    const icon = document.createElement("img");
-    icon.src = iconUrl;
-    icon.className = "ft-stories-overlay-icon";
+    const icon = Utils.createBadge("ft-stories-overlay-icon");
     const text = document.createElement("span");
     text.textContent = "Stories Hidden";
     overlay.appendChild(icon);

--- a/content-ig.js
+++ b/content-ig.js
@@ -1,6 +1,7 @@
 const Instagram = {
   initialized: false,
   observer: null,
+  checkScheduled: false,
   isRedirecting: false,
   currentMode: "strict",
   lastPath: "",
@@ -31,6 +32,7 @@ const Instagram = {
         changes.ft_timer_type ||
         changes.hide_ig_stories ||
         changes.hide_ig_reels_nav ||
+        changes.hide_ig_suggested ||
         changes.popup_visible_ig ||
         changes.restrictHiddenPlatforms ||
         changes.visualHideHiddenPlatforms
@@ -46,14 +48,23 @@ const Instagram = {
     if (!document.body) return;
     if (!this.observer) {
       this.observer = Utils.trackObserver(
-        new MutationObserver(() => this.runChecks()),
+        new MutationObserver(() => this.scheduleChecks()),
       );
       this.observer.observe(document.body, { childList: true, subtree: true });
     }
   },
+  scheduleChecks: function () {
+    if (this.checkScheduled) return;
+    this.checkScheduled = true;
+    requestAnimationFrame(() => {
+      this.checkScheduled = false;
+      this.runChecks();
+    });
+  },
   disable: function () {
     this.isRedirecting = false;
     UI.remove();
+    IGFeed.disable();
     this.removeStoriesOverlay();
     this.applyVisible(
       document.body.querySelectorAll(this.igSelectors.nav.reels),
@@ -71,6 +82,7 @@ const Instagram = {
   },
   runChecks: function () {
     if (!Utils.isExtensionEnabled()) {
+      IGFeed.disable();
       this.removeStoriesOverlay();
       this.applyVisible(
         document.body.querySelectorAll(this.igSelectors.nav.reels),
@@ -94,6 +106,7 @@ const Instagram = {
       action = "remove";
       reason = "break timer";
       this.showNavLinks();
+      IGFeed.sync();
       this.removeStoriesOverlay();
       Utils.debugLog("ig", {
         path,
@@ -161,6 +174,7 @@ const Instagram = {
     } else {
       this.removeStoriesOverlay();
     }
+    IGFeed.sync();
     Utils.debugLog("ig", {
       path,
       mode: this.currentMode,
@@ -322,6 +336,507 @@ const Instagram = {
     }
   },
 };
+/* --------------------------------------------------------------------------
+ * IGFeed - hide home-feed posts that are not from accounts you follow.
+ *
+ * Instagram's home feed is already limited to accounts you follow, plus two
+ * injected classes of post: "Suggested for you" and "Sponsored". So there is
+ * no follow list to fetch or store - filtering those two classes out leaves
+ * exactly the people you follow. Everything here is local DOM work; no
+ * network calls, no new permissions.
+ *
+ * Hidden posts are collapsed to a stub rather than removed, so the feed keeps
+ * some height and Instagram's infinite scroll does not spin. If too many
+ * posts in a row are filtered we stop filtering entirely and say so - the
+ * feed has simply run out of people you follow.
+ * ------------------------------------------------------------------------ */
+const IGFeed = {
+  COLLAPSED_CLASS: "ft-ig-collapsed",
+  STUB_CLASS: "ft-ig-stub",
+  // A collapsed post keeps the height it had, so the page never gets shorter
+  // and Instagram's infinite scroll is not goaded into loading more. This is
+  // the whole defence against runaway pagination.
+  MIN_COLLAPSED_HEIGHT: 400,
+  MAX_COLLAPSE_PER_TICK: 8,
+  MAX_STUB_REPAIRS: 3,
+  TICK_INTERVAL_MS: 100,
+  UNBOUNDED_SCAN: 20,
+  MAX_BUTTON_TEXT: 24,
+  ZERO_WIDTH: /[\u200B-\u200F\u202A-\u202E\u2060-\u2064\uFEFF\u00AD]/g,
+  SPONSORED_LABELS: ["sponsored", "paid partnership"],
+  SUGGESTED_LABELS: [
+    "suggested for you",
+    "suggested post",
+    "suggested posts",
+    "recommended for you",
+  ],
+  // Instagram's "You're all caught up" card, which it puts between the last
+  // post from someone you follow and the suggestions below. The illustration
+  // is a fixed asset path - not a hashed class, not a heading that could be
+  // anything else, and identical in every interface language.
+  //
+  // It is also temporary: Instagram unmounts the card once it scrolls out of
+  // view. So being past it cannot be recomputed each pass - it is recorded on
+  // the posts themselves, and outlives the card.
+  DIVIDER_MARK: 'img[src*="illo-confirm-refresh"]',
+  NON_PROFILE_PATH:
+    /^\/(explore|reel|reels|direct|stories|accounts|p|about|legal|privacy)(\/|$)/,
+
+  observer: null,
+  root: null,
+  collapsed: new Set(),
+  lastRevealAllowed: null,
+  scheduled: false,
+  trailingTimer: null,
+  lastTick: 0,
+  lastPath: null,
+  sawDivider: false,
+  active: false,
+
+  norm: function (text) {
+    return (text || "").replace(this.ZERO_WIDTH, "").replace(/\s+/g, " ").trim();
+  },
+  isFeedPath: function (path) {
+    return path === "/" || path === "";
+  },
+  revealAllowed: function () {
+    // Strict means strict: no way to peek at a hidden post. A running work
+    // timer forces strict everywhere else in the extension, so it does here.
+    if (FocusState.isWork) return false;
+    return CONFIG.platformSettings.ig !== "strict";
+  },
+  shouldRun: function () {
+    return (
+      Utils.isExtensionEnabled() &&
+      this.isFeedPath(window.location.pathname) &&
+      FocusState.shouldBlock &&
+      CONFIG.visualHiding.igSuggested &&
+      Utils.shouldApplyVisualHiding("ig")
+    );
+  },
+  sync: function () {
+    const path = window.location.pathname;
+    if (path !== this.lastPath) {
+      this.lastPath = path;
+    }
+    if (this.shouldRun()) this.enable();
+    else this.disable();
+  },
+  enable: function () {
+    this.active = true;
+    this.ensureObserver();
+    this.schedule();
+  },
+  disable: function () {
+    if (!this.active && !this.collapsed.size) return;
+    this.active = false;
+    if (this.observer) this.observer.disconnect();
+    this.root = null;
+    if (this.trailingTimer) {
+      clearTimeout(this.trailingTimer);
+      this.trailingTimer = null;
+    }
+    this.scheduled = false;
+    this.restoreAll();
+  },
+  findFeedRoot: function () {
+    return (
+      document.querySelector('main[role="main"]') ||
+      document.querySelector("main") ||
+      null
+    );
+  },
+  ensureObserver: function () {
+    const root = this.findFeedRoot();
+    if (!root) return;
+    if (!this.observer) {
+      // Reused for the life of the page so repeated enable/disable cycles do
+      // not pile up entries in Utils.observers.
+      this.observer = Utils.trackObserver(
+        new MutationObserver((records) => {
+          for (const record of records) {
+            if (!record.addedNodes.length) continue;
+            const target = record.target;
+            const post =
+              target && target.nodeType === 1 ? target.closest("article") : null;
+            // Video buffering, like counts, caption expansion - churn inside a
+            // post we have already judged tells us nothing new.
+            if (post && post.dataset.ftIgClass) continue;
+            this.schedule();
+            return;
+          }
+        }),
+      );
+    }
+    if (this.root !== root) {
+      this.observer.disconnect();
+      this.root = root;
+      this.observer.observe(root, { childList: true, subtree: true });
+    }
+  },
+  schedule: function () {
+    if (!this.active || this.scheduled) return;
+    this.scheduled = true;
+    const wait = Math.max(0, this.TICK_INTERVAL_MS - (Date.now() - this.lastTick));
+    const run = () => {
+      this.trailingTimer = null;
+      this.lastTick = Date.now();
+      requestAnimationFrame(() => {
+        this.scheduled = false;
+        this.tick();
+      });
+    };
+    if (wait === 0) run();
+    else this.trailingTimer = setTimeout(run, wait);
+  },
+  tick: function () {
+    if (!this.active) return;
+    if (!this.shouldRun()) {
+      this.disable();
+      return;
+    }
+    this.ensureObserver();
+    if (!this.root) return;
+    Utils.pruneDetachedElements(this.collapsed);
+
+    // Switching between strict and warn changes whether the stubs offer a way
+    // through, so redraw the ones already on screen.
+    const revealAllowed = this.revealAllowed();
+    if (revealAllowed !== this.lastRevealAllowed) {
+      this.lastRevealAllowed = revealAllowed;
+      this.collapsed.forEach((post) =>
+        this.renderStub(post, post.dataset.ftIgClass),
+      );
+    }
+
+    // Articles and section headings together, in document order. Instagram
+    // ends the followed part of the feed with a divider carrying an <h3>
+    // ("Suggested Posts"); every post below it is a suggestion, whatever its
+    // own markup says. Only honoured after a real post has gone by, so a
+    // stray heading above the feed can never blank the whole thing.
+    // Posts and the caught-up card together, in document order. Queried from
+    // the document rather than the feed root, so where Instagram chooses to
+    // put the card is not another assumption to get wrong; posts outside the
+    // feed are skipped below.
+    const nodes = document.querySelectorAll("article, " + this.DIVIDER_MARK);
+    let collapsedThisTick = 0;
+    let pastDivider = false;
+    let run = 0;
+
+    nodes.forEach((node) => {
+      if (node.tagName === "IMG") {
+        pastDivider = true;
+        this.sawDivider = true;
+        return;
+      }
+      const post = node;
+      if (!this.root.contains(post)) return;
+      // Either we have just walked past the card, or this post was stamped on
+      // an earlier pass while the card still existed. Both mean everything
+      // from here down is a suggestion.
+      if (post.dataset.ftIgBelow === "1") pastDivider = true;
+      else if (pastDivider) post.dataset.ftIgBelow = "1";
+      if (post.dataset.ftIgGiveUp === "1") {
+        run = 0;
+        if (this.collapsed.has(post)) this.restore(post);
+        return;
+      }
+      if (post.dataset.ftIgReveal === "1") {
+        if (revealAllowed) {
+          run = 0;
+          if (this.collapsed.has(post)) this.restore(post);
+          return;
+        }
+        // Dropping into strict mode retracts anything revealed under warn.
+        delete post.dataset.ftIgReveal;
+      }
+      const kind = this.classify(post, pastDivider);
+      // "pending" means the post has not painted its chrome yet. Look again
+      // next tick rather than judging it early.
+      if (kind === "pending") return;
+      if (kind === "keep") {
+        run = 0;
+        if (this.collapsed.has(post)) this.restore(post);
+        return;
+      }
+      if (this.collapsed.has(post)) {
+        this.repairStub(post, kind);
+      } else {
+        if (collapsedThisTick >= this.MAX_COLLAPSE_PER_TICK) return;
+        this.collapse(post, kind);
+        collapsedThisTick += 1;
+      }
+      run += 1;
+    });
+
+    // Written to the body every pass, so the state can be read from the page
+    // console with `document.body.dataset.ftIgFeed` - no extension APIs, no
+    // debug flag. Attribute writes do not feed back into our own observer,
+    // which watches childList only.
+    const state = {
+      root: this.root ? this.root.tagName.toLowerCase() : null,
+      posts: this.root.querySelectorAll("article").length,
+      hidden: this.collapsed.size,
+      run,
+      pastDivider,
+      // The card is transient, so 0 here is normal once it has scrolled away.
+      dividerMarks: document.querySelectorAll(this.DIVIDER_MARK).length,
+      sawDivider: this.sawDivider,
+      belowStamped: this.root.querySelectorAll('article[data-ft-ig-below="1"]')
+        .length,
+      stubsSized: this.root.querySelectorAll(".ft-ig-stub[style]").length,
+      docHeight: document.scrollingElement
+        ? document.scrollingElement.scrollHeight
+        : 0,
+    };
+    if (document.body) document.body.dataset.ftIgFeed = JSON.stringify(state);
+    Utils.debugLog("ig-feed", state);
+  },
+  postChrome: function (post) {
+    // Feed posts carry no <header>. The like/comment/share <section> is the
+    // one stable landmark, and everything above it - avatar, username, time,
+    // follow control, any "Suggested"/"Sponsored" label - is the post's own
+    // chrome. Everything below is the caption and its trimmings.
+    return post.querySelector("section");
+  },
+  inChrome: function (boundary, node) {
+    if (!boundary) return true;
+    return !!(
+      boundary.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_PRECEDING
+    );
+  },
+  labelNodes: function (post) {
+    // Short text leaves in the post's chrome. Deliberately stops before the
+    // caption - a caption that happens to say "sponsored" must not read as an
+    // ad label.
+    const boundary = this.postChrome(post);
+    const labels = [];
+    const walker = document.createTreeWalker(post, NodeFilter.SHOW_TEXT);
+    let node;
+    while ((node = walker.nextNode())) {
+      if (!this.inChrome(boundary, node)) break;
+      if (!boundary && labels.length >= this.UNBOUNDED_SCAN) break;
+      const text = this.norm(node.nodeValue).toLowerCase();
+      if (text && text.length <= 40) labels.push(text);
+    }
+    return labels;
+  },
+  followButton: function (post) {
+    // A follow control in the post's own chrome is the plainest statement
+    // Instagram makes that this is not somebody you follow - and it says it
+    // in whatever language the interface is in, so there is no word list to
+    // keep up to date. Icon-only controls ("More options") and the counters
+    // in the action bar are excluded by the svg and boundary checks.
+    const boundary = this.postChrome(post);
+    const controls = post.querySelectorAll('[role="button"], button');
+    for (const control of controls) {
+      if (!this.inChrome(boundary, control)) break;
+      if (control.querySelector("svg")) continue;
+      const text = this.norm(control.textContent);
+      if (text && text.length <= this.MAX_BUTTON_TEXT) return control;
+    }
+    return null;
+  },
+  author: function (post) {
+    const links = post.querySelectorAll('a[href^="/"]');
+    for (const link of links) {
+      const href = link.getAttribute("href") || "";
+      if (this.NON_PROFILE_PATH.test(href)) continue;
+      const match = href.match(/^\/([A-Za-z0-9._]+)\/$/);
+      if (match) return match[1];
+    }
+    return null;
+  },
+  classify: function (post, pastDivider) {
+    const cached = post.dataset.ftIgClass;
+    if (cached === "ad" || cached === "suggested") return cached;
+    // A cached "keep" is only good while the post is still above the divider.
+    // Instagram renders the divider after the posts below it have already been
+    // judged, so the stamp has to be reconsidered once it turns up.
+    if (cached === "keep" && !pastDivider) return "keep";
+    const labels = this.labelNodes(post);
+    const hasTime = !!post.querySelector("time[datetime]");
+    if (
+      labels.some((text) =>
+        this.SPONSORED_LABELS.some((label) => text.startsWith(label)),
+      )
+    ) {
+      post.dataset.ftIgClass = "ad";
+      return "ad";
+    }
+    // Ads route their call-to-action through Instagram's link shim and carry
+    // no post timestamp - a language-independent second signal.
+    if (!hasTime && post.querySelector('a[href*="l.instagram.com/"]')) {
+      post.dataset.ftIgClass = "ad";
+      return "ad";
+    }
+    if (
+      labels.some((text) =>
+        this.SUGGESTED_LABELS.some((label) => text.includes(label)),
+      ) ||
+      this.followButton(post) ||
+      pastDivider
+    ) {
+      post.dataset.ftIgClass = "suggested";
+      return "suggested";
+    }
+    // Only commit to "keep" once the post has really rendered, so a label
+    // that paints a moment late is not missed for good. Fail open otherwise.
+    if (hasTime && this.author(post)) {
+      post.dataset.ftIgClass = "keep";
+      return "keep";
+    }
+    return "pending";
+  },
+  feedList: function (post) {
+    // The lowest ancestor holding more than one post: the list Instagram
+    // appends to. Used to tell its "Suggested Posts" divider apart from a
+    // heading that belongs to something else on the page.
+    let node = post.parentElement;
+    while (node && node !== this.root) {
+      if (node.querySelectorAll("article").length > 1) return node;
+      node = node.parentElement;
+    }
+    return this.root;
+  },
+  measureHeight: function (post) {
+    // Measured before collapsing, while the post is still laid out. The floor
+    // covers a post whose media has not loaded yet and would otherwise pin
+    // the page at a height it never really had.
+    const height = Math.round(post.getBoundingClientRect().height);
+    return Math.max(height, this.MIN_COLLAPSED_HEIGHT);
+  },
+  collapse: function (post, kind) {
+    // Measured before collapsing, then carried on a data attribute. It cannot
+    // live in an inline style on the post: Instagram re-renders these nodes
+    // and blanks their style attribute, which is what defeated every earlier
+    // attempt to hold the page height. Attributes and classes survive; the
+    // height is applied to our own stub, which Instagram does not manage.
+    post.dataset.ftIgHeight = String(this.measureHeight(post));
+    post.classList.add(this.COLLAPSED_CLASS);
+    this.collapsed.add(post);
+    this.renderStub(post, kind);
+  },
+  restore: function (post) {
+    if (!post) return;
+    post.classList.remove(this.COLLAPSED_CLASS);
+    delete post.dataset.ftIgHeight;
+    post
+      .querySelectorAll(":scope > ." + this.STUB_CLASS)
+      .forEach((el) => el.remove());
+    this.collapsed.delete(post);
+  },
+  restoreAll: function () {
+    [...this.collapsed].forEach((post) => this.restore(post));
+    this.collapsed.clear();
+    this.lastRevealAllowed = null;
+    this.sawDivider = false;
+    document
+      .querySelectorAll('article[data-ft-ig-below="1"]')
+      .forEach((post) => delete post.dataset.ftIgBelow);
+    document
+      .querySelectorAll("." + this.COLLAPSED_CLASS)
+      .forEach((post) => this.restore(post));
+    document
+      .querySelectorAll("." + this.STUB_CLASS)
+      .forEach((el) => el.remove());
+  },
+  repairStub: function (post, kind) {
+    if (post.querySelector(":scope > ." + this.STUB_CLASS)) return;
+    // Instagram re-rendered the post out from under us. Put the stub back a
+    // few times, then leave the post alone rather than fight React forever.
+    const attempts = parseInt(post.dataset.ftIgStubs || "0", 10);
+    if (attempts >= this.MAX_STUB_REPAIRS) {
+      post.dataset.ftIgGiveUp = "1";
+      this.restore(post);
+      return;
+    }
+    this.renderStub(post, kind);
+  },
+  renderStub: function (post, kind) {
+    let stub = post.querySelector(":scope > ." + this.STUB_CLASS);
+    if (!stub) {
+      stub = document.createElement("div");
+      stub.className = this.STUB_CLASS;
+      if (CONFIG.isDarkMode) stub.classList.add("dark");
+      post.appendChild(stub);
+      post.dataset.ftIgStubs = String(
+        parseInt(post.dataset.ftIgStubs || "0", 10) + 1,
+      );
+    }
+    const height = parseInt(post.dataset.ftIgHeight || "0", 10);
+    if (height > 0) stub.style.setProperty("height", height + "px", "important");
+    while (stub.firstChild) stub.removeChild(stub.firstChild);
+
+    // Drawn inline rather than loaded from the extension. An <img> pointing at
+    // chrome-extension:// fails as "chrome-extension://invalid/" whenever the
+    // extension context is replaced - on every reload of an unpacked build -
+    // and the page retries it, which is where the endless GET errors came
+    // from. This asks the network for nothing.
+    const NS = "http://www.w3.org/2000/svg";
+    const icon = document.createElementNS(NS, "svg");
+    icon.setAttribute("viewBox", "0 0 64 64");
+    icon.setAttribute("width", "64");
+    icon.setAttribute("height", "64");
+    icon.setAttribute("aria-hidden", "true");
+    icon.setAttribute("class", "ft-ig-stub-icon");
+    const plate = document.createElementNS(NS, "rect");
+    plate.setAttribute("x", "2");
+    plate.setAttribute("y", "2");
+    plate.setAttribute("width", "60");
+    plate.setAttribute("height", "60");
+    plate.setAttribute("rx", "16");
+    plate.setAttribute("fill", "#4facfe");
+    const ring = document.createElementNS(NS, "circle");
+    ring.setAttribute("cx", "32");
+    ring.setAttribute("cy", "32");
+    ring.setAttribute("r", "15");
+    ring.setAttribute("fill", "none");
+    ring.setAttribute("stroke", "#fff");
+    ring.setAttribute("stroke-width", "4");
+    const slash = document.createElementNS(NS, "line");
+    slash.setAttribute("x1", "21");
+    slash.setAttribute("y1", "21");
+    slash.setAttribute("x2", "43");
+    slash.setAttribute("y2", "43");
+    slash.setAttribute("stroke", "#fff");
+    slash.setAttribute("stroke-width", "4");
+    slash.setAttribute("stroke-linecap", "round");
+    icon.appendChild(plate);
+    icon.appendChild(ring);
+    icon.appendChild(slash);
+    stub.appendChild(icon);
+
+    const title = document.createElement("h3");
+    title.textContent = kind === "ad" ? "Sponsored post" : "Suggested post";
+    stub.appendChild(title);
+
+    const subtitle = document.createElement("p");
+    const author = this.author(post);
+    subtitle.textContent =
+      kind === "ad"
+        ? "We're keeping you productive."
+        : author
+          ? "@" + author + " is not someone you follow."
+          : "Not from someone you follow.";
+    stub.appendChild(subtitle);
+
+    if (this.revealAllowed()) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "ft-ig-stub-btn";
+      button.textContent = "View Anyway";
+      button.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        post.dataset.ftIgReveal = "1";
+        this.restore(post);
+      });
+      stub.appendChild(button);
+    }
+  },
+};
+
 if (Site.isIG()) {
   if (window.__ftSettingsReady) Instagram.init();
   else document.addEventListener("ft-settings-ready", () => Instagram.init());

--- a/content-ig.js
+++ b/content-ig.js
@@ -276,8 +276,6 @@ const Instagram = {
     set.clear();
   },
   showStoriesOverlay: function () {
-    const iconUrl = Utils.getExtensionUrl("icons/icon48.png");
-    if (!iconUrl) return;
     if (document.getElementById(this.storiesOverlayId)) return;
     const storyTray = this.findStoriesTray();
     if (!storyTray) return;
@@ -286,9 +284,7 @@ const Instagram = {
     overlay.id = this.storiesOverlayId;
     overlay.className = "ft-stories-overlay";
     if (CONFIG.isDarkMode) overlay.classList.add("dark");
-    const icon = document.createElement("img");
-    icon.src = iconUrl;
-    icon.className = "ft-stories-overlay-icon";
+    const icon = Utils.createBadge("ft-stories-overlay-icon");
     const text = document.createElement("span");
     text.textContent = "Stories Hidden";
     overlay.appendChild(icon);
@@ -768,44 +764,7 @@ const IGFeed = {
     if (height > 0) stub.style.setProperty("height", height + "px", "important");
     while (stub.firstChild) stub.removeChild(stub.firstChild);
 
-    // Drawn inline rather than loaded from the extension. An <img> pointing at
-    // chrome-extension:// fails as "chrome-extension://invalid/" whenever the
-    // extension context is replaced - on every reload of an unpacked build -
-    // and the page retries it, which is where the endless GET errors came
-    // from. This asks the network for nothing.
-    const NS = "http://www.w3.org/2000/svg";
-    const icon = document.createElementNS(NS, "svg");
-    icon.setAttribute("viewBox", "0 0 64 64");
-    icon.setAttribute("width", "64");
-    icon.setAttribute("height", "64");
-    icon.setAttribute("aria-hidden", "true");
-    icon.setAttribute("class", "ft-ig-stub-icon");
-    const plate = document.createElementNS(NS, "rect");
-    plate.setAttribute("x", "2");
-    plate.setAttribute("y", "2");
-    plate.setAttribute("width", "60");
-    plate.setAttribute("height", "60");
-    plate.setAttribute("rx", "16");
-    plate.setAttribute("fill", "#4facfe");
-    const ring = document.createElementNS(NS, "circle");
-    ring.setAttribute("cx", "32");
-    ring.setAttribute("cy", "32");
-    ring.setAttribute("r", "15");
-    ring.setAttribute("fill", "none");
-    ring.setAttribute("stroke", "#fff");
-    ring.setAttribute("stroke-width", "4");
-    const slash = document.createElementNS(NS, "line");
-    slash.setAttribute("x1", "21");
-    slash.setAttribute("y1", "21");
-    slash.setAttribute("x2", "43");
-    slash.setAttribute("y2", "43");
-    slash.setAttribute("stroke", "#fff");
-    slash.setAttribute("stroke-width", "4");
-    slash.setAttribute("stroke-linecap", "round");
-    icon.appendChild(plate);
-    icon.appendChild(ring);
-    icon.appendChild(slash);
-    stub.appendChild(icon);
+    stub.appendChild(Utils.createBadge("ft-ig-stub-icon"));
 
     const title = document.createElement("h3");
     title.textContent = kind === "ad" ? "Sponsored post" : "Suggested post";

--- a/content-li.js
+++ b/content-li.js
@@ -352,9 +352,7 @@ const LinkedIn = {
     overlay.className = "ft-stories-overlay";
     overlay.dataset.ftDismiss = showDismiss ? "true" : "false";
     if (CONFIG.isDarkMode) overlay.classList.add("dark");
-    const icon = document.createElement("img");
-    icon.src = chrome.runtime.getURL("icons/icon48.png");
-    icon.className = "ft-stories-overlay-icon";
+    const icon = Utils.createBadge("ft-stories-overlay-icon");
     const text = document.createElement("span");
     text.textContent = title;
     overlay.appendChild(icon);
@@ -380,9 +378,7 @@ const LinkedIn = {
     overlay.id = id;
     overlay.className = "ft-linkedin-overlay";
     if (CONFIG.isDarkMode) overlay.classList.add("dark");
-    const icon = document.createElement("img");
-    icon.src = chrome.runtime.getURL("icons/icon128.png");
-    icon.className = "ft-linkedin-overlay-icon";
+    const icon = Utils.createBadge("ft-linkedin-overlay-icon");
     const h3 = document.createElement("h3");
     h3.textContent = title;
     const subtitle = document.createElement("p");
@@ -760,44 +756,7 @@ const LIFeed = {
       stub.style.setProperty("height", height + "px", "important");
     }
 
-    // Drawn inline rather than loaded from the extension. An <img> pointing at
-    // chrome-extension:// fails as "chrome-extension://invalid/" whenever the
-    // extension context is replaced - on every reload of an unpacked build -
-    // and the page retries it, which is where the endless GET errors came
-    // from. This asks the network for nothing.
-    const NS = "http://www.w3.org/2000/svg";
-    const icon = document.createElementNS(NS, "svg");
-    icon.setAttribute("viewBox", "0 0 64 64");
-    icon.setAttribute("width", "64");
-    icon.setAttribute("height", "64");
-    icon.setAttribute("aria-hidden", "true");
-    icon.setAttribute("class", "ft-li-stub-icon");
-    const plate = document.createElementNS(NS, "rect");
-    plate.setAttribute("x", "2");
-    plate.setAttribute("y", "2");
-    plate.setAttribute("width", "60");
-    plate.setAttribute("height", "60");
-    plate.setAttribute("rx", "16");
-    plate.setAttribute("fill", "#4facfe");
-    const ring = document.createElementNS(NS, "circle");
-    ring.setAttribute("cx", "32");
-    ring.setAttribute("cy", "32");
-    ring.setAttribute("r", "15");
-    ring.setAttribute("fill", "none");
-    ring.setAttribute("stroke", "#fff");
-    ring.setAttribute("stroke-width", "4");
-    const slash = document.createElementNS(NS, "line");
-    slash.setAttribute("x1", "21");
-    slash.setAttribute("y1", "21");
-    slash.setAttribute("x2", "43");
-    slash.setAttribute("y2", "43");
-    slash.setAttribute("stroke", "#fff");
-    slash.setAttribute("stroke-width", "4");
-    slash.setAttribute("stroke-linecap", "round");
-    icon.appendChild(plate);
-    icon.appendChild(ring);
-    icon.appendChild(slash);
-    stub.appendChild(icon);
+    stub.appendChild(Utils.createBadge("ft-li-stub-icon"));
     const title = document.createElement("h3");
     title.textContent = kind === "ad" ? "Promoted post" : "Not in your network";
     stub.appendChild(title);

--- a/content-li.js
+++ b/content-li.js
@@ -37,6 +37,7 @@ const LinkedIn = {
         changes.ft_timer_type ||
         changes.hide_li_feed ||
         changes.hide_li_addfeed ||
+        changes.hide_li_suggested ||
         changes.popup_visible_li ||
         changes.restrictHiddenPlatforms ||
         changes.visualHideHiddenPlatforms
@@ -66,6 +67,7 @@ const LinkedIn = {
     }
     this.removeAllOverlays();
     this.clearDismissalFlags();
+    LIFeed.disable();
     if (this.observer) this.observer.disconnect();
     this.observer = null;
   },
@@ -77,6 +79,7 @@ const LinkedIn = {
   },
   runChecks: function () {
     if (!Utils.isExtensionEnabled()) {
+      LIFeed.disable();
       this.removeAllOverlays();
       return;
     }
@@ -96,6 +99,7 @@ const LinkedIn = {
     if (!FocusState.shouldBlock) {
       action = "remove";
       reason = "focus not active";
+      LIFeed.sync();
       this.removeAllOverlays();
       Utils.debugLog("li", {
         path,
@@ -179,6 +183,7 @@ const LinkedIn = {
     } else {
       this.removeSidebarOverlays();
     }
+    LIFeed.sync();
     Utils.debugLog("li", {
       path,
       mode: this.currentMode,
@@ -418,6 +423,408 @@ const LinkedIn = {
     this.removeFeedOverlay();
     this.removeSidebarOverlays();
     UI.remove();
+  },
+};
+/* --------------------------------------------------------------------------
+ * LIFeed - hide feed posts from people you are not connected to.
+ *
+ * Same shape as the Instagram module, and deliberately so: every mark is a
+ * data attribute or a class, never an inline style. LinkedIn re-renders its
+ * feed nodes and blanks their style attribute; attributes survive.
+ *
+ * Two signals, both structural rather than textual, because the interface is
+ * not always in English:
+ *   - a Follow control in the post header. LinkedIn only offers it for people
+ *     you do not already follow, which is the question being asked. It is
+ *     found by the plus icon it contains (svg id "add-small"), not by its
+ *     label.
+ *   - a call-to-action leaving LinkedIn directly. Organic posts route external
+ *     links through linkedin.com/safety/go/; only promoted posts link straight
+ *     out. Backed up by the "Promoted" label where the language matches.
+ * ------------------------------------------------------------------------ */
+const LIFeed = {
+  COLLAPSED_CLASS: "ft-li-collapsed",
+  STUB_CLASS: "ft-li-stub",
+  // The plus icon on "Follow" and the person-plus icon on "Connect". Both say
+  // the same thing: this is not somebody you are already connected to. Found
+  // by icon rather than by label, so the interface language does not matter.
+  CONNECT_ICONS: ["add-small", "connect-small"],
+  // Marks the start of the post body. Everything above it is the header,
+  // which is the only place a "Promoted" label is trustworthy - the caption
+  // is not.
+  BODY_MARK: '[data-testid="expandable-text-box"]',
+  MIN_COLLAPSED_HEIGHT: 260,
+  MAX_COLLAPSE_PER_TICK: 8,
+  MAX_STUB_REPAIRS: 3,
+  TICK_INTERVAL_MS: 100,
+  PROMOTED_LABELS: ["promoted", "sponsored"],
+
+  observer: null,
+  root: null,
+  collapsed: new Set(),
+  scheduled: false,
+  trailingTimer: null,
+  lastTick: 0,
+  lastPath: null,
+  lastRevealAllowed: null,
+  active: false,
+
+  norm: function (text) {
+    return (text || "").replace(/\s+/g, " ").trim();
+  },
+  isFeedPath: function (path) {
+    return path === "/" || path === "" || path.startsWith("/feed");
+  },
+  revealAllowed: function () {
+    if (FocusState.isWork) return false;
+    return CONFIG.platformSettings.li !== "strict";
+  },
+  shouldRun: function () {
+    return (
+      Utils.isExtensionEnabled() &&
+      this.isFeedPath(window.location.pathname) &&
+      FocusState.shouldBlock &&
+      CONFIG.visualHiding.liSuggested &&
+      Utils.shouldApplyVisualHiding("li")
+    );
+  },
+  sync: function () {
+    const path = window.location.pathname;
+    if (path !== this.lastPath) this.lastPath = path;
+    if (this.shouldRun()) this.enable();
+    else this.disable();
+  },
+  enable: function () {
+    this.active = true;
+    this.ensureObserver();
+    this.schedule();
+  },
+  disable: function () {
+    if (!this.active && !this.collapsed.size) return;
+    this.active = false;
+    if (this.observer) this.observer.disconnect();
+    this.root = null;
+    if (this.trailingTimer) {
+      clearTimeout(this.trailingTimer);
+      this.trailingTimer = null;
+    }
+    this.scheduled = false;
+    this.restoreAll();
+  },
+  findFeedRoot: function () {
+    return document.querySelector("main") || null;
+  },
+  ensureObserver: function () {
+    const root = this.findFeedRoot();
+    if (!root) return;
+    if (!this.observer) {
+      this.observer = Utils.trackObserver(
+        new MutationObserver((records) => {
+          for (const record of records) {
+            if (!record.addedNodes.length) continue;
+            const target = record.target;
+            const post =
+              target && target.nodeType === 1
+                ? target.closest('[role="listitem"]')
+                : null;
+            if (post && post.dataset.ftLiClass) continue;
+            this.schedule();
+            return;
+          }
+        }),
+      );
+    }
+    if (this.root !== root) {
+      this.observer.disconnect();
+      this.root = root;
+      this.observer.observe(root, { childList: true, subtree: true });
+    }
+  },
+  schedule: function () {
+    if (!this.active || this.scheduled) return;
+    this.scheduled = true;
+    const wait = Math.max(
+      0,
+      this.TICK_INTERVAL_MS - (Date.now() - this.lastTick),
+    );
+    const run = () => {
+      this.trailingTimer = null;
+      this.lastTick = Date.now();
+      requestAnimationFrame(() => {
+        this.scheduled = false;
+        this.tick();
+      });
+    };
+    if (wait === 0) run();
+    else this.trailingTimer = setTimeout(run, wait);
+  },
+  posts: function () {
+    // Top-level feed items only. A reshared post nests another listitem, and
+    // judging the inner one would collapse a piece of an outer post.
+    return [...this.root.querySelectorAll('[role="listitem"]')].filter(
+      (el) => !el.parentElement || !el.parentElement.closest('[role="listitem"]'),
+    );
+  },
+  tick: function () {
+    if (!this.active) return;
+    if (!this.shouldRun()) {
+      this.disable();
+      return;
+    }
+    this.ensureObserver();
+    if (!this.root) return;
+    Utils.pruneDetachedElements(this.collapsed);
+
+    const revealAllowed = this.revealAllowed();
+    if (revealAllowed !== this.lastRevealAllowed) {
+      this.lastRevealAllowed = revealAllowed;
+      this.collapsed.forEach((post) =>
+        this.renderStub(post, post.dataset.ftLiClass),
+      );
+    }
+
+    let collapsedThisTick = 0;
+    this.posts().forEach((post) => {
+      if (post.dataset.ftLiGiveUp === "1") {
+        if (this.collapsed.has(post)) this.restore(post);
+        return;
+      }
+      if (post.dataset.ftLiReveal === "1") {
+        if (revealAllowed) {
+          if (this.collapsed.has(post)) this.restore(post);
+          return;
+        }
+        delete post.dataset.ftLiReveal;
+      }
+      const kind = this.classify(post);
+      if (kind === "pending") return;
+      if (kind === "keep") {
+        if (this.collapsed.has(post)) this.restore(post);
+        return;
+      }
+      if (this.collapsed.has(post)) {
+        this.repairStub(post, kind);
+        return;
+      }
+      if (collapsedThisTick >= this.MAX_COLLAPSE_PER_TICK) return;
+      this.collapse(post, kind);
+      collapsedThisTick += 1;
+    });
+  },
+  followButton: function (post) {
+    const selector = this.CONNECT_ICONS.map(
+      (id) => 'svg[id="' + id + '"]',
+    ).join(", ");
+    // A link, not only a button: "Connect" is rendered as an anchor.
+    const controls = post.querySelectorAll("button, a");
+    for (const control of controls) {
+      if (control.querySelector(selector)) return control;
+    }
+    return null;
+  },
+  headerLabels: function (post) {
+    // Short text leaves above the post body. Scoped that way so a caption
+    // that happens to say "promoted" is not read as an ad label.
+    const body = post.querySelector(this.BODY_MARK);
+    const labels = [];
+    const walker = document.createTreeWalker(post, NodeFilter.SHOW_TEXT);
+    let node;
+    while ((node = walker.nextNode())) {
+      if (body) {
+        const pos = body.compareDocumentPosition(node);
+        const inside = !!(pos & Node.DOCUMENT_POSITION_CONTAINED_BY);
+        const before = !!(pos & Node.DOCUMENT_POSITION_PRECEDING);
+        if (inside || !before) break;
+      } else if (labels.length >= 20) {
+        break;
+      }
+      const text = this.norm(node.nodeValue).toLowerCase();
+      if (text && text.length <= 40) labels.push(text);
+    }
+    return labels;
+  },
+  isRendered: function (post) {
+    // The action bar is the last thing to paint, so its presence means the
+    // header - and any Follow or Connect control in it - has already been
+    // rendered.
+    return (
+      !!post.querySelector('a[href*="/in/"], a[href*="/company/"]') &&
+      !!post.querySelector('svg[id="thumbs-up-outline-small"]')
+    );
+  },
+  author: function (post) {
+    // The header's own aria-label, e.g. "Almaz Salyakhov, Open to work
+    // Verified Profile 2nd". Taking the first profile link instead picks up
+    // the "Followed by ..." line above the post, which names whoever surfaced
+    // it rather than who wrote it.
+    const labelled = post.querySelector(
+      'a[href*="/in/"] [aria-label], a[href*="/company/"] [aria-label]',
+    );
+    if (labelled) {
+      // e.g. "Kirill Sadchikov  2nd", "ST Engineering Verified",
+      // "Almaz Salyakhov, Open to work Verified Profile 2nd".
+      const label = this.norm(labelled.getAttribute("aria-label"))
+        .split(",")[0]
+        .replace(/\s*•?\s*(1st|2nd|3rd\+?)\s*$/i, "")
+        .replace(/\s+verified\s*$/i, "")
+        .trim();
+      if (label) return label.slice(0, 60);
+    }
+    const links = post.querySelectorAll('a[href*="/in/"], a[href*="/company/"]');
+    for (const link of links) {
+      const name = this.norm(link.textContent);
+      if (name) return name.slice(0, 60);
+    }
+    return null;
+  },
+  classify: function (post) {
+    const cached = post.dataset.ftLiClass;
+    if (cached === "ad" || cached === "suggested" || cached === "keep") {
+      return cached;
+    }
+    const rendered = this.isRendered(post);
+    const labels = this.headerLabels(post);
+    if (
+      labels.some((text) =>
+        this.PROMOTED_LABELS.some((label) => text.startsWith(label)),
+      )
+    ) {
+      post.dataset.ftLiClass = "ad";
+      return "ad";
+    }
+    if (rendered && this.followButton(post)) {
+      post.dataset.ftLiClass = "suggested";
+      return "suggested";
+    }
+    // Fail open: nothing is judged until the post has actually painted.
+    if (rendered) {
+      post.dataset.ftLiClass = "keep";
+      return "keep";
+    }
+    return "pending";
+  },
+  measureHeight: function (post) {
+    const height = Math.round(post.getBoundingClientRect().height);
+    return Math.max(height, this.MIN_COLLAPSED_HEIGHT);
+  },
+  collapse: function (post, kind) {
+    post.dataset.ftLiHeight = String(this.measureHeight(post));
+    post.classList.add(this.COLLAPSED_CLASS);
+    this.collapsed.add(post);
+    this.renderStub(post, kind);
+  },
+  restore: function (post) {
+    if (!post) return;
+    post.classList.remove(this.COLLAPSED_CLASS);
+    delete post.dataset.ftLiHeight;
+    post
+      .querySelectorAll(":scope > ." + this.STUB_CLASS)
+      .forEach((el) => el.remove());
+    this.collapsed.delete(post);
+  },
+  restoreAll: function () {
+    [...this.collapsed].forEach((post) => this.restore(post));
+    this.collapsed.clear();
+    this.lastRevealAllowed = null;
+    document
+      .querySelectorAll("." + this.COLLAPSED_CLASS)
+      .forEach((post) => this.restore(post));
+    document
+      .querySelectorAll("." + this.STUB_CLASS)
+      .forEach((el) => el.remove());
+  },
+  repairStub: function (post, kind) {
+    if (post.querySelector(":scope > ." + this.STUB_CLASS)) return;
+    const attempts = parseInt(post.dataset.ftLiStubs || "0", 10);
+    if (attempts >= this.MAX_STUB_REPAIRS) {
+      post.dataset.ftLiGiveUp = "1";
+      this.restore(post);
+      return;
+    }
+    this.renderStub(post, kind);
+  },
+  renderStub: function (post, kind) {
+    let stub = post.querySelector(":scope > ." + this.STUB_CLASS);
+    if (!stub) {
+      stub = document.createElement("div");
+      stub.className = this.STUB_CLASS;
+      if (CONFIG.isDarkMode) stub.classList.add("dark");
+      post.appendChild(stub);
+      post.dataset.ftLiStubs = String(
+        parseInt(post.dataset.ftLiStubs || "0", 10) + 1,
+      );
+    }
+    while (stub.firstChild) stub.removeChild(stub.firstChild);
+    const height = parseInt(post.dataset.ftLiHeight || "0", 10);
+    if (height > 0) {
+      stub.style.setProperty("height", height + "px", "important");
+    }
+
+    // Drawn inline rather than loaded from the extension. An <img> pointing at
+    // chrome-extension:// fails as "chrome-extension://invalid/" whenever the
+    // extension context is replaced - on every reload of an unpacked build -
+    // and the page retries it, which is where the endless GET errors came
+    // from. This asks the network for nothing.
+    const NS = "http://www.w3.org/2000/svg";
+    const icon = document.createElementNS(NS, "svg");
+    icon.setAttribute("viewBox", "0 0 64 64");
+    icon.setAttribute("width", "64");
+    icon.setAttribute("height", "64");
+    icon.setAttribute("aria-hidden", "true");
+    icon.setAttribute("class", "ft-li-stub-icon");
+    const plate = document.createElementNS(NS, "rect");
+    plate.setAttribute("x", "2");
+    plate.setAttribute("y", "2");
+    plate.setAttribute("width", "60");
+    plate.setAttribute("height", "60");
+    plate.setAttribute("rx", "16");
+    plate.setAttribute("fill", "#4facfe");
+    const ring = document.createElementNS(NS, "circle");
+    ring.setAttribute("cx", "32");
+    ring.setAttribute("cy", "32");
+    ring.setAttribute("r", "15");
+    ring.setAttribute("fill", "none");
+    ring.setAttribute("stroke", "#fff");
+    ring.setAttribute("stroke-width", "4");
+    const slash = document.createElementNS(NS, "line");
+    slash.setAttribute("x1", "21");
+    slash.setAttribute("y1", "21");
+    slash.setAttribute("x2", "43");
+    slash.setAttribute("y2", "43");
+    slash.setAttribute("stroke", "#fff");
+    slash.setAttribute("stroke-width", "4");
+    slash.setAttribute("stroke-linecap", "round");
+    icon.appendChild(plate);
+    icon.appendChild(ring);
+    icon.appendChild(slash);
+    stub.appendChild(icon);
+    const title = document.createElement("h3");
+    title.textContent = kind === "ad" ? "Promoted post" : "Not in your network";
+    stub.appendChild(title);
+
+    const subtitle = document.createElement("p");
+    const author = this.author(post);
+    subtitle.textContent =
+      kind === "ad"
+        ? "We're keeping you productive."
+        : author
+          ? author + " is not someone you follow."
+          : "Not from someone you follow.";
+    stub.appendChild(subtitle);
+
+    if (this.revealAllowed()) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "ft-li-stub-btn";
+      button.textContent = "View Anyway";
+      button.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        post.dataset.ftLiReveal = "1";
+        this.restore(post);
+      });
+      stub.appendChild(button);
+    }
   },
 };
 if (Site.isLI()) {

--- a/content.css
+++ b/content.css
@@ -287,3 +287,156 @@ body.ft-platform-li aside.scaffold-layout__aside {
   border-radius: 8px;
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
 }
+
+/* Collapsed "suggested / sponsored" feed posts on Instagram.
+   The collapse itself is gated on the body class, so turning the setting off
+   reveals every post immediately, before any script has run. The inline
+   min-height set at collapse time holds the post's original height, so the
+   page never shortens under Instagram's infinite scroll. */
+body.ft-hide-ig-suggested.ft-platform-ig
+  article.ft-ig-collapsed
+  > *:not(.ft-ig-stub) {
+  display: none !important;
+}
+body.ft-hide-ig-suggested.ft-platform-ig article.ft-ig-collapsed {
+  /* No height is set on the post itself: Instagram blanks its style
+     attribute on re-render. The stub carries the height instead, and the
+     post takes it from the stub. */
+  display: block !important;
+  box-sizing: border-box !important;
+}
+.ft-ig-stub {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  text-align: center;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  box-sizing: border-box;
+  overflow: hidden;
+  user-select: none !important;
+}
+.ft-ig-stub.dark {
+  background: #1b1f23;
+  border-color: #38434f;
+}
+.ft-ig-stub-icon {
+  width: 64px;
+  height: 64px;
+  flex: 0 0 auto;
+  margin-bottom: 16px;
+  filter: drop-shadow(0 4px 8px rgba(79, 172, 254, 0.3));
+}
+.ft-ig-stub h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+  color: #1d1d1f;
+}
+.ft-ig-stub.dark h3 {
+  color: #fff;
+}
+.ft-ig-stub p {
+  font-size: 13px;
+  color: #6e6e73;
+  margin: 0 0 16px 0;
+  max-width: 320px;
+  overflow-wrap: anywhere;
+}
+.ft-ig-stub.dark p {
+  color: #a0a0a0;
+}
+.ft-ig-stub-btn {
+  padding: 10px 20px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  border: none;
+  border-radius: 99px;
+  background: #007aff;
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.ft-ig-stub-btn:hover {
+  opacity: 0.85;
+}
+
+/* LinkedIn: posts from outside your network, and promoted posts. Same shape
+   as the Instagram blocks - the collapse is gated on the body class so
+   turning the setting off reveals everything before any script runs, and the
+   height lives on our own stub because LinkedIn blanks the style attribute on
+   its own nodes. */
+body.ft-hide-li-suggested.ft-platform-li
+  .ft-li-collapsed
+  > *:not(.ft-li-stub) {
+  display: none !important;
+}
+body.ft-hide-li-suggested.ft-platform-li .ft-li-collapsed {
+  display: block !important;
+  box-sizing: border-box !important;
+}
+.ft-li-stub {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  text-align: center;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  box-sizing: border-box;
+  overflow: hidden;
+  user-select: none !important;
+}
+.ft-li-stub.dark {
+  background: #1b1f23;
+  border-color: #38434f;
+}
+.ft-li-stub-icon {
+  width: 64px;
+  height: 64px;
+  flex: 0 0 auto;
+  margin-bottom: 16px;
+  filter: drop-shadow(0 4px 8px rgba(79, 172, 254, 0.3));
+}
+.ft-li-stub h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+  color: #1d1d1f;
+}
+.ft-li-stub.dark h3 {
+  color: #fff;
+}
+.ft-li-stub p {
+  font-size: 13px;
+  color: #6e6e73;
+  margin: 0 0 16px 0;
+  max-width: 320px;
+  overflow-wrap: anywhere;
+}
+.ft-li-stub.dark p {
+  color: #a0a0a0;
+}
+.ft-li-stub-btn {
+  padding: 10px 20px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  border: none;
+  border-radius: 99px;
+  background: #007aff;
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.ft-li-stub-btn:hover {
+  opacity: 0.85;
+}

--- a/options.js
+++ b/options.js
@@ -22,10 +22,12 @@ document.addEventListener("DOMContentLoaded", function () {
     hide_yt_shorts_shelves: true,
     hide_yt_most_relevant_shelf: true,
     hide_ig_reels_nav: true,
+    hide_ig_suggested: true,
     hide_fb_reels_nav: true,
     hide_fb_people_you_might_know: true,
     hide_li_feed: true,
     hide_li_addfeed: true,
+    hide_li_suggested: true,
     showBreakButton: true,
     accentColor: "#4facfe",
   };
@@ -651,6 +653,11 @@ const platforms = {
         label: "Hide Reels Button",
         desc: "Hide the Reels tab in navigation",
       },
+      {
+        id: "hide_ig_suggested",
+        label: "Hide posts you don't follow",
+        desc: "Replaces suggested and sponsored posts in the feed with a placeholder, and ends the feed once Instagram runs out of people you follow",
+      },
     ],
   },
   tt: { name: "TikTok", settings: [] },
@@ -679,13 +686,18 @@ const platforms = {
     settings: [
       {
         id: "hide_li_feed",
-        label: "Hide Feed",
-        desc: "Hide the main feed section",
+        label: "Cover the whole feed",
+        desc: "Puts one panel over the entire feed. Independent of the setting below - this hides everything, that hides only what is not from your network",
       },
       {
         id: "hide_li_addfeed",
-        label: "Hide Add to Feed",
-        desc: "Hide suggested follows",
+        label: "Hide follow suggestions",
+        desc: 'Hides the "Add to your feed" box in the sidebar',
+      },
+      {
+        id: "hide_li_suggested",
+        label: "Hide posts outside your network",
+        desc: "Replaces posts from people you are not connected to, and promoted posts, with a placeholder. Leaves the rest of the feed alone",
       },
     ],
   },

--- a/popup.js
+++ b/popup.js
@@ -269,6 +269,7 @@ const PLATFORM_SETTINGS = {
   ig: [
     { key: "hide_ig_stories", label: "Hide Stories" },
     { key: "hide_ig_reels_nav", label: "Hide Reels Button" },
+    { key: "hide_ig_suggested", label: "Hide posts you don't follow" },
   ],
   fb: [
     { key: "hide_fb_stories", label: "Hide Stories" },
@@ -279,8 +280,9 @@ const PLATFORM_SETTINGS = {
     },
   ],
   li: [
-    { key: "hide_li_feed", label: "Hide Feed" },
-    { key: "hide_li_addfeed", label: 'Hide "Add to Your Feed"' },
+    { key: "hide_li_feed", label: "Cover the whole feed" },
+    { key: "hide_li_addfeed", label: "Hide follow suggestions" },
+    { key: "hide_li_suggested", label: "Hide posts outside your network" },
   ],
   tt: [],
 };


### PR DESCRIPTION
Adds one setting per platform — `hide_ig_suggested` and `hide_li_suggested`, both default on — that replaces feed posts you have no relationship with by a placeholder block, leaving the rest of the feed alone.

**No network calls, no new permissions, no manifest change.** `chrome-manifest.json` and `firefox-manifest.json` are byte-identical to `main`.

---

## Why this shape

Both feeds are already limited to accounts you follow, plus two injected classes of post: suggestions and ads. Filtering those two out therefore leaves exactly the people you chose — with **no follow list to fetch, store or refresh**, and nothing that touches an API. That was a deliberate constraint, since anything else would have meant scraping a connections list.

## Instagram — `IGFeed` in `content-ig.js`

**Where a post's chrome ends.** Feed posts have no `<header>`. The like/comment/share `<section>` turns out to be the one stable landmark, so the chrome is everything above it, and only that is scanned. A caption reading "check out this sponsored content" must not register as an ad label. Zero-width characters are stripped first, since the Sponsored label is padded with them.

**The primary signal is the follow control.** Its presence in the post's chrome is the plainest statement Instagram makes that this is not somebody you follow — and it says it in whatever language the interface is in, which a word list would not. Icon-only controls are excluded by their `<svg>`; the like and repost counters, which are also text-bearing `role=button` elements, fall outside the chrome boundary.

**Some posts carry no follow control at all.** A collab post between two accounts is identical in markup to a post from someone you do follow. For those, Instagram's own "You're all caught up" card is the signal: everything below it is a suggestion. It is found by its illustration —

```js
DIVIDER_MARK: 'img[src*="illo-confirm-refresh"]'
```

— a fixed asset path rather than a hashed class or a generic tag, and identical in every interface language (verified against captures of that card in English and in Russian, which differ in every text node and not at all in the image path).

That card is unmounted once it scrolls out of view, so being past it cannot be recomputed each pass. The posts below it are stamped instead, and the stamp outlives the card.

## LinkedIn — `LIFeed` in `content-li.js`

The same two signals in LinkedIn's terms.

**A Follow or Connect control in the post header,** found by its icon (`svg#add-small`, `svg#connect-small`) rather than its label. Connect is rendered as an `<a>`, not a `<button>`; Like, Comment, Repost and Send carry different icons, so they cannot be mistaken for it.

**Promoted posts by their header label,** read only above the `[data-testid="expandable-text-box"]` that starts the post body — same reasoning as Instagram's caption. Note that "links straight out of LinkedIn rather than through `linkedin.com/safety/go/`" is *not* a usable ad signal: promoted posts route their call-to-action through the safety redirect exactly as organic posts do.

## What it does to the page

**Nothing with inline styles.** Both sites blank the `style` attribute on their own nodes when they re-render — a collapsed post comes back as `<article data-ft-ig-class="keep" style="">`. Data attributes and classes survive, so every mark is one of those.

A collapsed post keeps the height it was measured at, carried on a data attribute and applied to the extension's own placeholder element rather than to the post. The page therefore does not shorten as posts are hidden, which is what would otherwise put the load-more sentinel back in view and drive the infinite scroll.

## Failing open

- A post is not judged until it has actually painted — a timestamp and an author on Instagram, the action bar on LinkedIn — so a control that renders a moment late is never missed.
- Anything unrecognised is left visible.
- If either site tears the placeholder out, it is restored at most three times and then that post is left alone rather than fighting the framework indefinitely.
- A reshared LinkedIn post nests a second `role="listitem"`; only the outer one is judged.

## Behaviour

- Strict mode, and a running work timer, offer no way past a hidden post. A post revealed under warn is retaken when the mode changes.
- The collapse is gated on a body class, so switching the setting off reveals everything before any script has run.
- **Bug fix included:** no content script builds a `chrome-extension://` URL any more. Every injected overlay loaded its icon from `chrome.runtime.getURL()`, and LinkedIn's two overlays called it with no guard. Once the extension context is replaced — which happens on every reload of an unpacked build while pages are open — that returns the literal `chrome-extension://invalid/`, and the page retries it for as long as it stays open, filling the console with `net::ERR_FAILED`. The mark is now drawn inline as SVG by one shared helper (`Utils.createBadge`), used by the warning card, the toast, the kick notification, the Instagram and Facebook stories overlays, both LinkedIn overlays, and the new blocks. `getExtensionUrl` is left in place but has no callers.
- Existing observers are unchanged in behaviour except that Instagram's body observer is now coalesced through `requestAnimationFrame` — it previously ran `runChecks()` on every mutation Instagram makes.

## Testing

Manual testing on both platforms per CONTRIBUTING: Instagram Reels/Explore blocking, Stories and Reels-nav hiding, LinkedIn feed and sidebar hiding, popup controls, per-platform modes, timer modes, and the options page — all unaffected.

Beyond that, 78 headless assertions against markup captured from live feeds cover classification, caption false positives, zero-width obfuscation, survival of a wiped `style` attribute, collapse/restore idempotence, and the mode gating. They are not included here: they need a jsdom dev dependency this repo does not have, and the fixtures are real posts from a real account. Happy to contribute them separately in whatever form suits you.

## Known limits, stated plainly

- Verified against **one account's feed, in English, over one day.** The signals are structural rather than textual, which should travel, but that is the extent of what has actually been observed.
- Instagram's infinite scroll is **not** stopped. Hiding posts does not shorten the page — measured live at 28,860px with ten posts mounted and everything below the divider hidden — so the height appears to come from something other than the posts. That work was removed rather than shipped half-working; this PR only hides posts.
- Settings labels for LinkedIn were reworded, since "Hide Feed" and a new "hide posts outside your network" both read as hiding the feed. They now say which is which. Happy to revert that if you would rather keep the existing wording.
