### PR TITLE
Draw the extension's mark inline instead of loading it over chrome-extension://

### DIFF
--- a/content-common.js
+++ b/content-common.js
@@ -101,42 +101,70 @@ const Utils = {
       return false;
     }
   },
-  // The extension's mark, drawn inline. Nothing here loads an image from
-  // chrome-extension://, because chrome.runtime.getURL() returns
+  // The FocusTube icon, drawn inline: the same gradient plate and four
+  // concentric rings as icons/icon128.png, measured off it - the plate inset
+  // and corner radius, each ring's radius and stroke width, and the two
+  // gradient stops - so this is the logo rather than a stand-in for it. The
+  // 128-unit viewBox keeps the icon's own padding, so every call site that
+  // sized the old <img> from a stylesheet keeps the size it had.
+  //
+  // Drawn rather than loaded because chrome.runtime.getURL() returns
   // "chrome-extension://invalid/" once the extension context has been replaced
   // - which happens on every reload of an unpacked build while pages are open
   // - and the page then retries that URL for as long as it stays open.
+  _badgeSeq: 0,
   createBadge: function (className) {
     const NS = "http://www.w3.org/2000/svg";
     const svg = document.createElementNS(NS, "svg");
-    svg.setAttribute("viewBox", "0 0 64 64");
+    svg.setAttribute("viewBox", "0 0 128 128");
     svg.setAttribute("aria-hidden", "true");
     if (className) svg.setAttribute("class", className);
+    // Ids are page-global, and several badges can be on screen at once: two
+    // gradients sharing an id would both resolve to whichever came first.
+    this._badgeSeq += 1;
+    const gradientId = "ft-badge-gradient-" + this._badgeSeq;
+    const defs = document.createElementNS(NS, "defs");
+    const gradient = document.createElementNS(NS, "linearGradient");
+    gradient.setAttribute("id", gradientId);
+    // Blue at the top right, cyan at the bottom left.
+    gradient.setAttribute("x1", "100%");
+    gradient.setAttribute("y1", "0%");
+    gradient.setAttribute("x2", "0%");
+    gradient.setAttribute("y2", "100%");
+    [
+      ["0%", "#0969db"],
+      ["100%", "#06cecb"],
+    ].forEach(([offset, color]) => {
+      const stop = document.createElementNS(NS, "stop");
+      stop.setAttribute("offset", offset);
+      stop.setAttribute("stop-color", color);
+      gradient.appendChild(stop);
+    });
+    defs.appendChild(gradient);
+    svg.appendChild(defs);
     const plate = document.createElementNS(NS, "rect");
-    plate.setAttribute("x", "2");
-    plate.setAttribute("y", "2");
-    plate.setAttribute("width", "60");
-    plate.setAttribute("height", "60");
-    plate.setAttribute("rx", "16");
-    plate.setAttribute("fill", "#4facfe");
-    const ring = document.createElementNS(NS, "circle");
-    ring.setAttribute("cx", "32");
-    ring.setAttribute("cy", "32");
-    ring.setAttribute("r", "15");
-    ring.setAttribute("fill", "none");
-    ring.setAttribute("stroke", "#fff");
-    ring.setAttribute("stroke-width", "4");
-    const slash = document.createElementNS(NS, "line");
-    slash.setAttribute("x1", "21");
-    slash.setAttribute("y1", "21");
-    slash.setAttribute("x2", "43");
-    slash.setAttribute("y2", "43");
-    slash.setAttribute("stroke", "#fff");
-    slash.setAttribute("stroke-width", "4");
-    slash.setAttribute("stroke-linecap", "round");
+    plate.setAttribute("x", "9");
+    plate.setAttribute("y", "9");
+    plate.setAttribute("width", "110");
+    plate.setAttribute("height", "110");
+    plate.setAttribute("rx", "44");
+    plate.setAttribute("fill", "url(#" + gradientId + ")");
     svg.appendChild(plate);
-    svg.appendChild(ring);
-    svg.appendChild(slash);
+    [
+      [6.35, 0.7],
+      [11.2, 1.6],
+      [17.8, 2.4],
+      [27.45, 3.5],
+    ].forEach(([radius, width]) => {
+      const ring = document.createElementNS(NS, "circle");
+      ring.setAttribute("cx", "64");
+      ring.setAttribute("cy", "64");
+      ring.setAttribute("r", String(radius));
+      ring.setAttribute("fill", "none");
+      ring.setAttribute("stroke", "#fff");
+      ring.setAttribute("stroke-width", String(width));
+      svg.appendChild(ring);
+    });
     return svg;
   },
   getExtensionUrl: function (path) {
@@ -784,7 +812,7 @@ const UI = {
       };
       btnGroup.appendChild(msgBtn);
     }
-    if (iconUrl) card.appendChild(img);
+    card.appendChild(img);
     card.append(h1, p, btnGroup);
     overlay.appendChild(card);
     target.appendChild(overlay);

--- a/content-common.js
+++ b/content-common.js
@@ -101,6 +101,44 @@ const Utils = {
       return false;
     }
   },
+  // The extension's mark, drawn inline. Nothing here loads an image from
+  // chrome-extension://, because chrome.runtime.getURL() returns
+  // "chrome-extension://invalid/" once the extension context has been replaced
+  // - which happens on every reload of an unpacked build while pages are open
+  // - and the page then retries that URL for as long as it stays open.
+  createBadge: function (className) {
+    const NS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(NS, "svg");
+    svg.setAttribute("viewBox", "0 0 64 64");
+    svg.setAttribute("aria-hidden", "true");
+    if (className) svg.setAttribute("class", className);
+    const plate = document.createElementNS(NS, "rect");
+    plate.setAttribute("x", "2");
+    plate.setAttribute("y", "2");
+    plate.setAttribute("width", "60");
+    plate.setAttribute("height", "60");
+    plate.setAttribute("rx", "16");
+    plate.setAttribute("fill", "#4facfe");
+    const ring = document.createElementNS(NS, "circle");
+    ring.setAttribute("cx", "32");
+    ring.setAttribute("cy", "32");
+    ring.setAttribute("r", "15");
+    ring.setAttribute("fill", "none");
+    ring.setAttribute("stroke", "#fff");
+    ring.setAttribute("stroke-width", "4");
+    const slash = document.createElementNS(NS, "line");
+    slash.setAttribute("x1", "21");
+    slash.setAttribute("y1", "21");
+    slash.setAttribute("x2", "43");
+    slash.setAttribute("y2", "43");
+    slash.setAttribute("stroke", "#fff");
+    slash.setAttribute("stroke-width", "4");
+    slash.setAttribute("stroke-linecap", "round");
+    svg.appendChild(plate);
+    svg.appendChild(ring);
+    svg.appendChild(slash);
+    return svg;
+  },
   getExtensionUrl: function (path) {
     try {
       if (!chrome.runtime?.id || !chrome.runtime?.getURL) return "";
@@ -693,10 +731,7 @@ const UI = {
     const target = document.body || document.documentElement;
     const card = document.createElement("div");
     card.className = "focus-tube-card";
-    const img = document.createElement("img");
-    const iconUrl = Utils.getExtensionUrl("icons/icon128.png");
-    if (iconUrl) img.src = iconUrl;
-    img.className = "focus-tube-icon-img";
+    const img = Utils.createBadge("focus-tube-icon-img");
     let headerText =
       type === "strict" ? "Strict Mode Active" : "Distraction Blocked";
     let bodyText = "FocusTube is keeping you productive.";
@@ -838,14 +873,9 @@ const UI = {
     const toast = document.createElement("div");
     toast.id = "ft-toast";
     toast.style.cssText = `position: fixed; top: 24px; right: 24px; background: #1f1f1f; color: #fff; padding: 16px 24px; border-radius: 12px; box-shadow: 0 10px 40px rgba(0,0,0,0.4); z-index: 2147483647; font-family: sans-serif; border: 1px solid rgba(255,255,255,0.1); display: flex; align-items: center; gap: 15px; opacity: 0; transform: translateY(-20px); transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1); min-width: 300px;`;
-    const iconUrl = Utils.getExtensionUrl("icons/icon128.png");
-    if (iconUrl) {
-      const icon = document.createElement("img");
-      icon.src = iconUrl;
-      icon.alt = "";
-      icon.style.cssText = "width:32px;height:32px;border-radius:8px;";
-      toast.appendChild(icon);
-    }
+    const icon = Utils.createBadge();
+    icon.style.cssText = "width:32px;height:32px;flex:0 0 auto;";
+    toast.appendChild(icon);
     const textWrap = document.createElement("div");
     const titleEl = document.createElement("div");
     titleEl.textContent = title;
@@ -880,14 +910,9 @@ const UI = {
             box-shadow: 0 10px 40px rgba(0,0,0,0.25), 0 0 0 1px rgba(255,255,255,0.1); 
             opacity: 0; transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
         `;
-    const iconUrl = Utils.getExtensionUrl("icons/icon128.png");
-    if (iconUrl) {
-      const icon = document.createElement("img");
-      icon.src = iconUrl;
-      icon.alt = "";
-      icon.style.cssText = "width:24px;height:24px;border-radius:6px;";
-      n.appendChild(icon);
-    }
+    const icon = Utils.createBadge();
+    icon.style.cssText = "width:24px;height:24px;flex:0 0 auto;";
+    n.appendChild(icon);
     const message = document.createElement("span");
     message.textContent = "Strict Mode prevented access.";
     n.appendChild(message);

--- a/content-fb.js
+++ b/content-fb.js
@@ -338,8 +338,6 @@ const Facebook = {
     );
   },
   showStoriesOverlay: function () {
-    const iconUrl = Utils.getExtensionUrl("icons/icon48.png");
-    if (!iconUrl) return;
     if (document.getElementById(this.storiesOverlayId)) return;
     const storiesContainer = document.querySelector('[aria-label="Stories"]');
     if (!storiesContainer) return;
@@ -353,9 +351,7 @@ const Facebook = {
     overlay.id = this.storiesOverlayId;
     overlay.className = "ft-stories-overlay";
     if (CONFIG.isDarkMode) overlay.classList.add("dark");
-    const icon = document.createElement("img");
-    icon.src = iconUrl;
-    icon.className = "ft-stories-overlay-icon";
+    const icon = Utils.createBadge("ft-stories-overlay-icon");
     const text = document.createElement("span");
     text.textContent = "Stories Hidden";
     overlay.appendChild(icon);

--- a/content-ig.js
+++ b/content-ig.js
@@ -262,8 +262,6 @@ const Instagram = {
     set.clear();
   },
   showStoriesOverlay: function () {
-    const iconUrl = Utils.getExtensionUrl("icons/icon48.png");
-    if (!iconUrl) return;
     if (document.getElementById(this.storiesOverlayId)) return;
     const storyTray = this.findStoriesTray();
     if (!storyTray) return;
@@ -272,9 +270,7 @@ const Instagram = {
     overlay.id = this.storiesOverlayId;
     overlay.className = "ft-stories-overlay";
     if (CONFIG.isDarkMode) overlay.classList.add("dark");
-    const icon = document.createElement("img");
-    icon.src = iconUrl;
-    icon.className = "ft-stories-overlay-icon";
+    const icon = Utils.createBadge("ft-stories-overlay-icon");
     const text = document.createElement("span");
     text.textContent = "Stories Hidden";
     overlay.appendChild(icon);

--- a/content-li.js
+++ b/content-li.js
@@ -347,9 +347,7 @@ const LinkedIn = {
     overlay.className = "ft-stories-overlay";
     overlay.dataset.ftDismiss = showDismiss ? "true" : "false";
     if (CONFIG.isDarkMode) overlay.classList.add("dark");
-    const icon = document.createElement("img");
-    icon.src = chrome.runtime.getURL("icons/icon48.png");
-    icon.className = "ft-stories-overlay-icon";
+    const icon = Utils.createBadge("ft-stories-overlay-icon");
     const text = document.createElement("span");
     text.textContent = title;
     overlay.appendChild(icon);
@@ -375,9 +373,7 @@ const LinkedIn = {
     overlay.id = id;
     overlay.className = "ft-linkedin-overlay";
     if (CONFIG.isDarkMode) overlay.classList.add("dark");
-    const icon = document.createElement("img");
-    icon.src = chrome.runtime.getURL("icons/icon128.png");
-    icon.className = "ft-linkedin-overlay-icon";
+    const icon = Utils.createBadge("ft-linkedin-overlay-icon");
     const h3 = document.createElement("h3");
     h3.textContent = title;
     const subtitle = document.createElement("p");

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/test/badge.test.mjs
+++ b/test/badge.test.mjs
@@ -1,0 +1,205 @@
+// The extension's icon is drawn inline rather than loaded from
+// chrome-extension://. These are the assertions that keep it that way, and
+// that keep the drawing the FocusTube logo rather than something else.
+import fs from "node:fs";
+import vm from "node:vm";
+import path from "node:path";
+import assert from "node:assert";
+import { fileURLToPath } from "node:url";
+import { JSDOM } from "jsdom";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(HERE, "..");
+const SRC = path.join(ROOT, "content-common.js");
+
+// Set by makeEnv; a call to chrome.runtime.getURL while this is on is a
+// failure, not a fallback, because that is the call the badge exists to avoid.
+let urlCallsBanned = false;
+
+function makeEnv() {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "https://www.instagram.com/",
+    pretendToBeVisual: true,
+  });
+  const w = dom.window;
+  const noop = () => {};
+  const chrome = {
+    runtime: {
+      id: "testid",
+      lastError: null,
+      getURL: (p) => {
+        if (urlCallsBanned) {
+          throw new Error("chrome.runtime.getURL called: " + p);
+        }
+        return "chrome-extension://testid/" + p;
+      },
+      sendMessage: noop,
+      onMessage: { addListener: noop },
+    },
+    storage: {
+      local: {
+        get: (keys, cb) => cb && cb({}),
+        set: (obj, cb) => cb && cb(),
+        remove: (keys, cb) => cb && cb(),
+      },
+      onChanged: { addListener: noop },
+    },
+  };
+  const ctx = vm.createContext({
+    window: w,
+    document: w.document,
+    location: w.location,
+    navigator: w.navigator,
+    MutationObserver: w.MutationObserver,
+    IntersectionObserver: w.IntersectionObserver,
+    CustomEvent: w.CustomEvent,
+    Node: w.Node,
+    Element: w.Element,
+    HTMLElement: w.HTMLElement,
+    getComputedStyle: w.getComputedStyle.bind(w),
+    requestAnimationFrame: w.requestAnimationFrame.bind(w),
+    cancelAnimationFrame: w.cancelAnimationFrame.bind(w),
+    matchMedia: w.matchMedia ? w.matchMedia.bind(w) : () => ({ matches: false, addEventListener: noop }),
+    setTimeout: w.setTimeout.bind(w),
+    clearTimeout: w.clearTimeout.bind(w),
+    setInterval: w.setInterval.bind(w),
+    clearInterval: w.clearInterval.bind(w),
+    sessionStorage: w.sessionStorage,
+    localStorage: w.localStorage,
+    console,
+    chrome,
+  });
+  ctx.globalThis = ctx;
+
+  // UI and Utils are top-level consts, so they do not reach globalThis on
+  // their own. Asserted rather than assumed: if the file's shape changes this
+  // fails here rather than silently testing nothing.
+  const source = fs.readFileSync(SRC, "utf8");
+  assert.ok(/\bconst UI = \{/.test(source), "UI is no longer a top-level const");
+  vm.runInContext(
+    source + "\n;globalThis.__ft = { UI, Utils, CONFIG, FocusState };",
+    ctx,
+  );
+  return { w, doc: w.document, ...ctx.__ft };
+}
+
+let failures = 0;
+const check = (name, fn) => {
+  try {
+    fn();
+    console.log("  PASS  " + name);
+  } catch (e) {
+    failures++;
+    console.log("  FAIL  " + name + "\n        " + e.message);
+  }
+};
+
+console.log("the blocking overlay");
+for (const type of ["strict", "warn"]) {
+  const { doc, UI, CONFIG } = makeEnv();
+  CONFIG.extensionEnabled = true;
+  urlCallsBanned = true;
+  let threw = null;
+  try {
+    UI.create(type, "ig", () => {}, () => {});
+  } catch (e) {
+    threw = e;
+  }
+  urlCallsBanned = false;
+
+  check(`${type}: UI.create() completes`, () => {
+    assert.equal(threw && threw.message, undefined, String(threw && threw.stack));
+  });
+  const overlay = doc.querySelector(".focus-tube-warning");
+  check(`${type}: the overlay is on the page`, () => assert.ok(overlay));
+  check(`${type}: the card carries the badge`, () => {
+    const badge = overlay.querySelector("svg.focus-tube-icon-img");
+    assert.ok(badge, "no badge in the card");
+    assert.equal(
+      badge.parentElement.className,
+      "focus-tube-card",
+      "badge is not a child of the card",
+    );
+  });
+  check(`${type}: nothing in the card is an <img>`, () =>
+    assert.equal(overlay.querySelector("img"), null));
+  check(`${type}: the header is the one for this mode`, () =>
+    assert.equal(
+      overlay.querySelector("h1").textContent,
+      type === "strict" ? "Strict Mode Active" : "Distraction Blocked",
+    ));
+}
+
+console.log("\nthe badge is the FocusTube logo");
+{
+  const { doc, Utils } = makeEnv();
+  const badge = Utils.createBadge("x");
+  const rings = [...badge.querySelectorAll("circle")];
+  check("a gradient plate, not a flat fill", () => {
+    const plate = badge.querySelector("rect");
+    assert.ok(plate, "no plate");
+    assert.match(plate.getAttribute("fill"), /^url\(#/);
+    const stops = [...badge.querySelectorAll("stop")].map((s) =>
+      s.getAttribute("stop-color"),
+    );
+    assert.deepEqual(stops, ["#0969db", "#06cecb"]);
+  });
+  check("four concentric rings, as on icons/icon128.png", () => {
+    assert.equal(rings.length, 4);
+    assert.deepEqual(
+      rings.map((r) => r.getAttribute("r")),
+      ["6.35", "11.2", "17.8", "27.45"],
+    );
+    assert.ok(rings.every((r) => r.getAttribute("cx") === "64"));
+    assert.ok(rings.every((r) => r.getAttribute("fill") === "none"));
+  });
+  check("no stray marks - nothing but the plate and the rings", () => {
+    const drawn = [...badge.querySelectorAll("*")].filter(
+      (el) => !["defs", "linearGradient", "stop"].includes(el.tagName),
+    );
+    assert.deepEqual(
+      drawn.map((el) => el.tagName),
+      ["rect", "circle", "circle", "circle", "circle"],
+    );
+  });
+  check("the icon's own padding is kept, so sizes do not shift", () => {
+    assert.equal(badge.getAttribute("viewBox"), "0 0 128 128");
+    const plate = badge.querySelector("rect");
+    assert.equal(plate.getAttribute("x"), "9");
+    assert.equal(plate.getAttribute("width"), "110");
+  });
+  check("two badges do not share a gradient id", () => {
+    const a = Utils.createBadge();
+    const b = Utils.createBadge();
+    const idOf = (el) => el.querySelector("linearGradient").getAttribute("id");
+    assert.notEqual(idOf(a), idOf(b));
+    assert.equal(a.querySelector("rect").getAttribute("fill"), `url(#${idOf(a)})`);
+  });
+  check("it is decorative, so screen readers skip it", () =>
+    assert.equal(badge.getAttribute("aria-hidden"), "true"));
+  check("the class asked for is the class it gets", () =>
+    assert.equal(badge.getAttribute("class"), "x"));
+}
+
+console.log("\nno content script builds an extension URL");
+{
+  const files = ["content-common.js", "content-fb.js", "content-ig.js", "content-li.js"];
+  for (const file of files) {
+    const src = fs.readFileSync(path.join(ROOT, file), "utf8");
+    check(`${file} never calls chrome.runtime.getURL outside the helper`, () => {
+      const calls = src.split("\n").filter((raw) => {
+        const line = raw.trim();
+        // Comments name it in passing; only real call sites count.
+        if (line.startsWith("//") || line.startsWith("*")) return false;
+        if (/getExtensionUrl: function|return chrome\.runtime\.getURL/.test(line)) {
+          return false;
+        }
+        return /chrome\.runtime\.getURL|Utils\.getExtensionUrl\(/.test(line);
+      });
+      assert.deepEqual(calls, [], calls.join("\n"));
+    });
+  }
+}
+
+console.log(failures ? `\n${failures} FAILURE(S)` : "\nall green");
+process.exit(failures ? 1 : 0);

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "focustube-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node badge.test.mjs"
+  },
+  "devDependencies": {
+    "jsdom": "^29.1.1"
+  }
+}


### PR DESCRIPTION
Split out of #11 at your request, so it can go in on its own.

### The bug

Reload an unpacked build while a Facebook, Instagram or LinkedIn tab is open and the console fills with:

```
GET chrome-extension://invalid/ net::ERR_FAILED
```

repeating for as long as the tab stays open.

Every overlay the extension injects loads its icon through `chrome.runtime.getURL()`. Once the extension context is replaced, that call returns the literal string `"chrome-extension://invalid/"`, and the `<img>` pointed at it retries forever. Two of the call sites — LinkedIn's sidebar and feed overlays — called `chrome.runtime.getURL()` directly with no guard at all, so they also threw when the context was gone.

### The fix

`Utils.createBadge()` draws the mark as inline SVG. No content script builds an extension URL or injects an `<img>` any more:

| file | call sites |
|---|---|
| `content-common.js` | warning card, toast, kick notification |
| `content-ig.js` | stories overlay |
| `content-fb.js` | stories overlay |
| `content-li.js` | sidebar overlay, feed overlay |

Guarding the remaining call sites would only have narrowed the window rather than closing it, and the extension has no need to fetch its own icon over a URL to draw a 32px badge.

`getExtensionUrl` is left in place; it just has no callers now.

### On layout

The three call sites that size their icon from the stylesheet — `.focus-tube-icon-img`, `.ft-stories-overlay-icon`, `.ft-linkedin-overlay-icon` — all set `width` and `height` explicitly, so replacing `<img>` with `<svg>` doesn't disturb them. The two that size it inline keep doing so. No CSS change was needed.

### Scope

No new permissions, no manifest change, no network calls. The only behavioural difference is that the icon now renders instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
