### PR TITLE
Add FocusTube landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="FocusTube blocks YouTube Shorts, Instagram Reels, TikTok, Facebook Reels and distracting LinkedIn feeds while keeping the useful parts of each site available.">
+  <meta name="theme-color" content="#111214">
+  <title>FocusTube | Block Shorts, Reels and distracting feeds</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="#top" aria-label="FocusTube home">FocusTube</a>
+    <nav aria-label="Primary navigation">
+      <a href="#privacy">Privacy</a>
+      <a href="https://github.com/malekwael229/FocusTube">GitHub</a>
+    </nav>
+  </header>
+
+  <main id="top">
+    <section class="hero section-shell">
+      <div class="hero-copy">
+        <p class="kicker">Free and open source</p>
+        <h1>Keep the useful parts. Block the scroll traps.</h1>
+        <p class="hero-text">FocusTube blocks YouTube Shorts, Instagram Reels, TikTok, Facebook Reels and the LinkedIn feed without blocking the whole site.</p>
+        <div class="store-actions" aria-label="Install FocusTube">
+          <a class="primary-button" href="https://chromewebstore.google.com/detail/focustube-distraction-blo/ppdjgkniggbikifojmkindmbhppmoell">Install for Chrome</a>
+          <a class="text-link" href="https://addons.mozilla.org/addon/focus-tube/">Firefox</a>
+          <a class="text-link" href="https://microsoftedge.microsoft.com/addons/detail/focustube/emffahlehkfdlknpmpndaabhigchhoog">Edge</a>
+        </div>
+        <p class="compatibility">Also works in Chromium browsers that support Chrome extensions.</p>
+      </div>
+
+      <div class="hero-visual" aria-label="FocusTube supported platforms">
+        <div class="browser-frame">
+          <div class="browser-bar" aria-hidden="true"><span></span><span></span><span></span></div>
+          <div class="browser-content">
+            <p class="browser-label">Distraction blocked</p>
+            <strong>YouTube Shorts</strong>
+            <p>Open the parts of YouTube you need without falling into Shorts.</p>
+            <div class="platform-list" aria-label="Supported platforms">
+              <span>YouTube</span><span>Instagram</span><span>TikTok</span><span>Facebook</span><span>LinkedIn</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-shell split-section" aria-labelledby="control-heading">
+      <div><h2 id="control-heading">Block distractions without blocking the entire site.</h2></div>
+      <div class="feature-list">
+        <article><h3>YouTube</h3><p>Block Shorts and hide distracting Shorts navigation and shelves.</p></article>
+        <article><h3>Instagram and TikTok</h3><p>Cut off Reels, Explore and common feed surfaces while keeping useful areas available.</p></article>
+        <article><h3>Facebook and LinkedIn</h3><p>Hide Reels, Stories, feed suggestions and LinkedIn feed distractions.</p></article>
+        <article><h3>Focus tools</h3><p>Use focus and break timers, browser notifications and local blocked-count estimates.</p></article>
+      </div>
+    </section>
+
+    <section class="section-shell privacy-section" id="privacy" aria-labelledby="privacy-heading">
+      <div class="privacy-copy">
+        <h2 id="privacy-heading">Your settings stay in your browser.</h2>
+        <p>FocusTube has no analytics, no telemetry, no account system and no project-controlled backend. Preferences and timer data use browser-local storage.</p>
+        <a class="text-link" href="https://github.com/malekwael229/FocusTube#privacy">Read the privacy notes on GitHub</a>
+      </div>
+      <dl class="privacy-facts">
+        <div><dt>No tracking</dt><dd>No analytics SDKs or telemetry calls.</dd></div>
+        <div><dt>No remote backend</dt><dd>FocusTube does not send your settings or browsing data to a FocusTube server.</dd></div>
+        <div><dt>Open source</dt><dd>The source, releases and testing documentation are public on GitHub.</dd></div>
+      </dl>
+    </section>
+
+    <section class="section-shell final-cta" aria-labelledby="cta-heading">
+      <h2 id="cta-heading">Make the sites you need less distracting.</h2>
+      <p>Install FocusTube for free and keep control of what shows up in your browser.</p>
+      <div class="store-actions" aria-label="Install FocusTube">
+        <a class="primary-button" href="https://chromewebstore.google.com/detail/focustube-distraction-blo/ppdjgkniggbikifojmkindmbhppmoell">Install for Chrome</a>
+        <a class="text-link" href="https://addons.mozilla.org/addon/focus-tube/">Firefox</a>
+        <a class="text-link" href="https://microsoftedge.microsoft.com/addons/detail/focustube/emffahlehkfdlknpmpndaabhigchhoog">Edge</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer"><span>FocusTube</span><a href="https://github.com/malekwael229/FocusTube">Source on GitHub</a></footer>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,362 @@
+:root {
+  color-scheme: dark;
+  --bg: #111214;
+  --panel: #191b1f;
+  --panel-2: #202329;
+  --text: #f5f7f8;
+  --muted: #a9b0b8;
+  --border: #30343a;
+  --accent: #4facfe;
+  --accent-strong: #8fd0ff;
+  --max-width: 1120px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, "Segoe UI Variable", "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+}
+
+a:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.site-header,
+.site-footer,
+.section-shell {
+  width: min(var(--max-width), calc(100% - 40px));
+  margin-inline: auto;
+}
+
+.site-header {
+  min-height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.brand {
+  font-size: 1.08rem;
+  font-weight: 760;
+  text-decoration: none;
+  letter-spacing: -0.02em;
+}
+
+nav {
+  display: flex;
+  gap: 22px;
+}
+
+nav a,
+.site-footer a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+nav a:hover,
+.site-footer a:hover,
+.text-link:hover {
+  color: var(--text);
+}
+
+.hero {
+  min-height: 650px;
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  align-items: center;
+  gap: 72px;
+  padding-block: 78px 96px;
+}
+
+.kicker,
+.browser-label {
+  margin: 0 0 14px;
+  color: var(--accent-strong);
+  font-size: 0.82rem;
+  font-weight: 720;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 760px;
+  margin-bottom: 24px;
+  font-size: clamp(3rem, 6vw, 5.5rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+h2 {
+  margin-bottom: 20px;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+h3 {
+  margin-bottom: 7px;
+  font-size: 1.03rem;
+}
+
+.hero-text {
+  max-width: 680px;
+  margin-bottom: 30px;
+  color: var(--muted);
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+}
+
+.store-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 18px;
+}
+
+.primary-button {
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 21px;
+  border: 1px solid var(--accent);
+  border-radius: 10px;
+  background: var(--accent);
+  color: #071119;
+  font-weight: 760;
+  text-decoration: none;
+}
+
+.primary-button:hover {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+}
+
+.text-link {
+  color: var(--accent-strong);
+  font-weight: 680;
+  text-underline-offset: 4px;
+}
+
+.compatibility {
+  margin: 16px 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.hero-visual {
+  display: flex;
+  justify-content: center;
+}
+
+.browser-frame {
+  width: min(100%, 510px);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--panel);
+}
+
+.browser-bar {
+  display: flex;
+  gap: 7px;
+  padding: 15px 17px;
+  border-bottom: 1px solid var(--border);
+}
+
+.browser-bar span {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #4b5159;
+}
+
+.browser-content {
+  padding: 46px 38px 40px;
+}
+
+.browser-content strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.browser-content > p:not(.browser-label) {
+  max-width: 390px;
+  color: var(--muted);
+}
+
+.platform-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 30px;
+}
+
+.platform-list span {
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: #d7dce1;
+  font-size: 0.86rem;
+}
+
+.split-section,
+.privacy-section {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 78px;
+  padding-block: 100px;
+  border-top: 1px solid var(--border);
+}
+
+.feature-list article {
+  padding: 0 0 24px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.feature-list article:last-child {
+  margin-bottom: 0;
+}
+
+.feature-list p,
+.privacy-copy > p,
+.final-cta > p,
+.privacy-facts dd {
+  color: var(--muted);
+}
+
+.privacy-facts {
+  margin: 0;
+}
+
+.privacy-facts div {
+  padding: 0 0 24px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.privacy-facts dt {
+  margin-bottom: 5px;
+  font-weight: 740;
+}
+
+.privacy-facts dd {
+  margin: 0;
+}
+
+.final-cta {
+  padding-block: 112px 126px;
+  border-top: 1px solid var(--border);
+}
+
+.final-cta h2,
+.final-cta > p {
+  max-width: 720px;
+}
+
+.final-cta > p {
+  margin-bottom: 28px;
+  font-size: 1.08rem;
+}
+
+.site-footer {
+  min-height: 86px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+@media (max-width: 820px) {
+  .hero,
+  .split-section,
+  .privacy-section {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    gap: 54px;
+    min-height: auto;
+    padding-block: 64px 80px;
+  }
+
+  .split-section,
+  .privacy-section {
+    gap: 42px;
+    padding-block: 78px;
+  }
+
+  h1 {
+    font-size: clamp(2.8rem, 13vw, 4.8rem);
+  }
+}
+
+@media (max-width: 540px) {
+  .site-header,
+  .site-footer,
+  .section-shell {
+    width: min(100% - 28px, var(--max-width));
+  }
+
+  .site-header {
+    min-height: 68px;
+  }
+
+  nav {
+    gap: 14px;
+    font-size: 0.92rem;
+  }
+
+  .hero {
+    padding-top: 52px;
+  }
+
+  .store-actions {
+    align-items: flex-start;
+  }
+
+  .primary-button {
+    width: 100%;
+  }
+
+  .browser-content {
+    padding: 34px 24px 30px;
+  }
+
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    padding-block: 24px;
+  }
+}


### PR DESCRIPTION
Adds a lightweight GitHub Pages landing page in `docs/` with direct store links, supported-platform information, and the existing privacy claims. No analytics, scripts, runtime dependencies, or extension code changes.